### PR TITLE
Add go import meta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,6 +3597,18 @@
             "prepend-http": "^2.0.0",
             "query-string": "^5.0.1",
             "sort-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "query-string": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+              "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+              "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+              }
+            }
           }
         },
         "prepend-http": {
@@ -13149,13 +13161,20 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
+      "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
       }
     },
     "querystring": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-transformer-sharp": "^2.1.9",
     "moment": "^2.24.0",
     "node-sass": "^4.11.0",
+    "query-string": "^6.9.0",
     "react": "^16.6.3",
     "react-dom": "^16.5.2",
     "react-helmet": "^5.2.0",

--- a/src/components/CustomHelmet.js
+++ b/src/components/CustomHelmet.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import Helmet from 'react-helmet';
+import { Location } from '@reach/router'
 
-
-const CustomHelmet = ({ page, image }) => (
+const CustomHelmet = ({ location, page, image }) => (
     <Helmet>
         <title>{page.title}</title>
         <meta
             name="viewport"
             content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+        />
+        <meta
+            name="go-import"
+            content={`${location.host}${location.pathname} git https://github.com/fossildev${location.pathname}`}
         />
         <meta name="twitter:site" content="@sosc" />
         <meta property="og:type" content="website" />
@@ -26,5 +30,15 @@ const CustomHelmet = ({ page, image }) => (
     </Helmet>
 )
 
+const WithLocation = ComponentToWrap => props => (
+    <Location>
+        {({ location }) => (
+            <ComponentToWrap
+                {...props}
+                location={location}
+            />
+        )}
+    </Location>
+)
 
-export default CustomHelmet
+export default WithLocation(CustomHelmet)

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import Layout from '../components/indexLayout';
+import GatsbyConfig from '../../gatsby-config'
+import CustomHelmet from '../components/CustomHelmet';
 
 const NotFoundPage = () => (
   <Layout>
+    <CustomHelmet page={GatsbyConfig.siteMetadata} />
     <div className="page">
     <div className="container">
       <h1>NOT FOUND</h1>


### PR DESCRIPTION
Add go-import metadata. This PR makes go project in this repository can be installed with org domain instead of github.com/fossildev `eg: go get fossil.or.id/myawesome-goproj`